### PR TITLE
Skip duplicate ms_id check when no ms_ids are present.

### DIFF
--- a/src/sutta_processor/application/check_service/bd_reference.py
+++ b/src/sutta_processor/application/check_service/bd_reference.py
@@ -169,15 +169,17 @@ class SCReferenceService:
             return duplicates
 
         counter = get_reference_counts()
-        duplicated_ms_id = get_surplus_ref(c=counter)
+        # Take into account when there might be references that don't have ms_ids, like Chinese texts.
+        if counter:
+            duplicated_ms_id = get_surplus_ref(c=counter)
 
-        if duplicated_ms_id:
-            omg = "[%s] There are '%s' duplicated ms_id in bilara references: %s"
-            log.error(omg, self.name, len(duplicated_ms_id[2]), duplicated_ms_id[2])
-            duplicated_ms_id.pop(2)
             if duplicated_ms_id:
-                omg = "[%s] There are multiple ms_id in bilara references: %s"
-                log.error(omg, self.name, duplicated_ms_id)
+                omg = "[%s] There are '%s' duplicated ms_id in bilara references: %s"
+                log.error(omg, self.name, len(duplicated_ms_id[2]), duplicated_ms_id[2])
+                duplicated_ms_id.pop(2)
+                if duplicated_ms_id:
+                    omg = "[%s] There are multiple ms_id in bilara references: %s"
+                    log.error(omg, self.name, duplicated_ms_id)
 
     @classmethod
     def get_references_stem(cls, reference: BilaraReferenceAggregate) -> list:

--- a/src/sutta_processor/application/use_cases/check_all_changes.py
+++ b/src/sutta_processor/application/use_cases/check_all_changes.py
@@ -31,8 +31,8 @@ def check_all_changes(cfg: Config, all_files: Dict[str, List[Path]]):
     if all_files['html'] and all_files['root']:
         bilara_check_html_from_files(cfg=cfg, html_file_paths=all_files['html'], root_file_paths=all_files['root'])
 
-    # if all_files['reference']:
-    #     bilara_check_references_from_files(cfg=cfg, ref_file_paths=all_files['reference'])
+    if all_files['reference']:
+        bilara_check_references_from_files(cfg=cfg, ref_file_paths=all_files['reference'])
 
     if all_files['root']:
         bilara_check_root_from_files(cfg=cfg, root_file_paths=all_files['root'])


### PR DESCRIPTION
Now handling case where there are no ms_ids.  So get_duplicate_ms_id (part of bilara_check_references) won't fail on Chinese texts.